### PR TITLE
Make it faster by RubyVM::AST

### DIFF
--- a/lib/rubocop-rubycw.rb
+++ b/lib/rubocop-rubycw.rb
@@ -8,4 +8,5 @@ require_relative 'rubocop/rubycw/inject'
 
 RuboCop::Rubycw::Inject.defaults!
 
+require_relative 'rubocop/rubycw/warning_capturer'
 require_relative 'rubocop/cop/rubycw_cops'

--- a/lib/rubocop/cop/rubycw/rubycw.rb
+++ b/lib/rubocop/cop/rubycw/rubycw.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'open3'
-require 'rbconfig'
-
 module RuboCop
   module Cop
     module Rubycw
@@ -12,20 +9,18 @@ module RuboCop
 
         def investigate(processed_source)
           source = processed_source.raw_source
-          _stdout, stderr, _status = Open3.capture3(ruby, '-cw', '-e', source)
 
-          stderr.each_line do |line|
-            line.chomp!
-            lnum = line[/-e:(\d+):/, 1].to_i
-            message = line[/-e:\d+: warning: (.+)$/, 1]
+          warnings(source).each do |line|
+            lnum = line[/.+:(\d+):/, 1].to_i
+            message = line[/.+:\d+: warning: (.+)$/, 1]
 
             range = source_range(processed_source.buffer, lnum, 0)
             add_offense(range, location: range, message: message)
           end
         end
 
-        def ruby
-          RbConfig.ruby
+        def warnings(source)
+          RuboCop::Rubycw::WarningCapturer.capture(source)
         end
       end
     end

--- a/lib/rubocop/rubycw/warning_capturer.rb
+++ b/lib/rubocop/rubycw/warning_capturer.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Rubycw
+    module WarningCapturer
+      if defined?(RubyVM::AbstractSyntaxTree)
+        require 'stringio'
+
+        module ::Warning
+          def warn(*message)
+            if WarningCapturer.warnings
+              WarningCapturer.warnings.concat message
+            else
+              super
+            end
+          end
+        end
+
+        def self.capture(source)
+          start
+          RubyVM::AbstractSyntaxTree.parse(source)
+          warnings.tap do
+            stop
+          end
+        end
+
+        def self.start
+          @warnings = []
+        end
+
+        def self.stop
+          @warnings = nil
+        end
+
+        def self.warnings
+          @warnings
+        end
+
+        stop
+      else
+        require 'rbconfig'
+        require 'open3'
+
+        def self.capture(source)
+          _stdout, stderr, _status = Open3.capture3(RbConfig.ruby, '-cw', '-e', source)
+          stderr.lines.map(&:chomp)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Close #1 

It uses RubyVM::AST, not Ripper. Because Ripper does not display warnings.

So it can affect to Ruby 2.6 or higher.