### PR TITLE
CI against Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,6 @@ steps: &steps
     - run: bundle exec rake
 
 jobs:
-
-  ruby-2.3:
-    docker:
-      - image: circleci/ruby:2.3
-    <<: *steps
-
   ruby-2.4:
     docker:
       - image: circleci/ruby:2.4
@@ -33,6 +27,11 @@ jobs:
       - image: circleci/ruby:2.7
     <<: *steps
 
+  ruby-3.0:
+    docker:
+      - image: circleci/ruby:3.0
+    <<: *steps
+
   ruby-head:
     docker:
       - image: rubocophq/circleci-ruby-snapshot:latest
@@ -42,9 +41,9 @@ workflows:
   version: 2
   build:
     jobs:
-      - ruby-2.3
       - ruby-2.4
       - ruby-2.5
       - ruby-2.6
       - ruby-2.7
+      - ruby-3.0
       - ruby-head


### PR DESCRIPTION
This patch also drops test for Ruby 2.3 in CircleCI.
It means rubocop-rubycw drops support of Ruby 2.3 "softly". We can still use this gem with Ruby 2.3 because the gemspec allows, but it is not recommended and no guarantee.