### PR TITLE
Use `Cop::Base` API

### DIFF
--- a/lib/rubocop/cop/rubycw/rubycw.rb
+++ b/lib/rubocop/cop/rubycw/rubycw.rb
@@ -4,10 +4,10 @@ module RuboCop
   module Cop
     module Rubycw
       # Execute `ruby -cw` and wrap the warning as RuboCop offense.
-      class Rubycw < Cop
+      class Rubycw < Base
         include RangeHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           source = processed_source.raw_source
 
           warnings(source).each do |line|
@@ -15,7 +15,7 @@ module RuboCop
             message = line[/.+:\d+: warning: (.+)$/, 1]
 
             range = source_range(processed_source.buffer, lnum, 0)
-            add_offense(range, location: range, message: message)
+            add_offense(range, message: message)
           end
         end
 

--- a/rubocop-rubycw.gemspec
+++ b/rubocop-rubycw.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Integrate RuboCop and ruby -cw}
   spec.description   = %q{Integrate RuboCop and ruby -cw}
   spec.homepage      = "https://github.com/rubocop-hq/rubocop-rubycw"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
   spec.license       = 'MIT'
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
@@ -27,6 +27,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rubocop'
+  spec.add_runtime_dependency 'rubocop', '~> 1.0'
 end
-


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/7868.

This PR uses `Cop::Base` API for `Rubycw` cop.
And it makes required Ruby version 2.4 or higher due to the update of the minimum support Ruby version of RuboCop 1.0.