### PR TITLE
Allow rubocop 1.73

### DIFF
--- a/rubocop-rubycw.gemspec
+++ b/rubocop-rubycw.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'lint_roller', '~> 1.1'
-  spec.add_runtime_dependency 'rubocop', '~> 1.72.1'
+  spec.add_runtime_dependency 'rubocop', '~> 1.72', '>= 1.72.1'
 end


### PR DESCRIPTION
Current gemspec required rubocop to be `'~> 1.72.1'`, which doesn't allow rubocop 1.73.

It's better to use `'~> 1.72', '>= 1.72.1'`.

This approach is used in other rubocop plugin gems, for example: https://github.com/rubocop/rubocop-factory_bot/blob/103168792b4e042a235825080b9e552f53be379a/rubocop-factory_bot.gemspec#L38C34-L38C56.